### PR TITLE
Move link bar above scroll line

### DIFF
--- a/style.css
+++ b/style.css
@@ -38,7 +38,7 @@ body {
 
 /* Overlay */
 #overlay {
-    min-height: 100vh;
+    min-height: 80.7vh;
 }
 .overlay-main {
     background-color: rgba(8, 103, 136, 0.8);


### PR DESCRIPTION
If the window is really tall, this tweak creates a small white gap at the bottom, but that should disappear when real content is added.

Edit: Examination of behavior on different monitors reveals that this doesn't have much effect if the window is below a different size. Oh well. At least it doesn't change the existing look on those displays.