### PR TITLE
Use calc() to dynamically calculate minimum height for #overlay

### DIFF
--- a/style.css
+++ b/style.css
@@ -39,6 +39,7 @@ body {
 /* Overlay */
 #overlay {
     min-height: 80.7vh;
+    min-height: calc(100vh - 232px);
 }
 .overlay-main {
     background-color: rgba(8, 103, 136, 0.8);


### PR DESCRIPTION
It was [@AkashBrave's idea](https://github.com/tjcsl/website/commit/8889f50aee1115e19fda9eb5283f41c8ab74af73#commitcomment-32552175); I just typed it up.